### PR TITLE
fix: handle stream_event message type in MessageParser

### DIFF
--- a/claude-code-sdk/src/main/java/org/springaicommunity/claude/agent/sdk/parsing/MessageParser.java
+++ b/claude-code-sdk/src/main/java/org/springaicommunity/claude/agent/sdk/parsing/MessageParser.java
@@ -70,6 +70,7 @@ public class MessageParser {
 			case "assistant" -> parseAssistantMessage(node);
 			case "system" -> parseSystemMessage(node);
 			case "result" -> parseResultMessage(node);
+			case "stream_event" -> parseStreamEventMessage(node);
 			default -> {
 				logger.error(
 						"Unrecognized message type '{}' — skipping. "
@@ -147,6 +148,38 @@ public class MessageParser {
 			.result(getStringField(node, "result"))
 			.structuredOutput(parseStructuredOutput(node.get("structured_output")))
 			.build();
+	}
+
+	/**
+	 * Parses a {@code stream_event} message emitted by the Claude CLI when
+	 * {@code includePartialMessages} is enabled.
+	 *
+	 * <p>Stream events wrap Anthropic API streaming events (e.g. {@code message_start},
+	 * {@code content_block_delta}, {@code message_stop}) inside a CLI envelope that carries
+	 * session and correlation metadata. This method extracts the inner {@code event} object
+	 * along with the CLI metadata and returns a typed {@link StreamEventMessage}.
+	 *
+	 * @param node the root JSON node with {@code "type": "stream_event"}
+	 * @return a {@link StreamEventMessage} instance
+	 */
+	private StreamEventMessage parseStreamEventMessage(JsonNode node) {
+		JsonNode eventNode = node.get("event");
+		String eventType = null;
+		Map<String, Object> eventData = null;
+
+		if (eventNode != null && !eventNode.isNull()) {
+			eventType = getStringField(eventNode, "type");
+			eventData = parseDataMap(eventNode);
+		}
+
+		String sessionId = getStringField(node, "session_id");
+		String uuid = getStringField(node, "uuid");
+		String parentToolUseId = getStringField(node, "parent_tool_use_id");
+		JsonNode ttftNode = node.get("ttft_ms");
+		Long ttftMs = (ttftNode != null && ttftNode.isNumber()) ? ttftNode.asLong() : null;
+
+		logger.debug("Processing stream_event with inner event type '{}', session='{}'", eventType, sessionId);
+		return StreamEventMessage.of(eventType, sessionId, uuid, parentToolUseId, ttftMs, eventData);
 	}
 
 	private Object parseStructuredOutput(JsonNode node) {

--- a/claude-code-sdk/src/main/java/org/springaicommunity/claude/agent/sdk/types/Message.java
+++ b/claude-code-sdk/src/main/java/org/springaicommunity/claude/agent/sdk/types/Message.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({ @JsonSubTypes.Type(value = UserMessage.class, name = "user"),
 		@JsonSubTypes.Type(value = AssistantMessage.class, name = "assistant"),
 		@JsonSubTypes.Type(value = SystemMessage.class, name = "system"),
-		@JsonSubTypes.Type(value = ResultMessage.class, name = "result") })
+		@JsonSubTypes.Type(value = ResultMessage.class, name = "result"),
+		@JsonSubTypes.Type(value = StreamEventMessage.class, name = "stream_event") })
 public interface Message {
 
 	/**

--- a/claude-code-sdk/src/main/java/org/springaicommunity/claude/agent/sdk/types/StreamEventMessage.java
+++ b/claude-code-sdk/src/main/java/org/springaicommunity/claude/agent/sdk/types/StreamEventMessage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Spring AI Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.claude.agent.sdk.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Represents a {@code stream_event} message emitted by the Claude CLI when
+ * {@code includePartialMessages} is enabled.
+ *
+ * <p>Stream events wrap intermediate Anthropic API streaming events such as
+ * {@code message_start}, {@code content_block_delta}, and {@code message_stop}.
+ * The outer envelope carries CLI-level metadata (session ID, UUID, TTFT), while
+ * the nested {@code event} object holds the actual Anthropic streaming event
+ * with its own {@code type} and payload.
+ *
+ * @see <a href="https://docs.anthropic.com/en/api/messages-streaming">Anthropic Streaming API</a>
+ */
+public record StreamEventMessage(
+
+		@JsonProperty("event_type") String eventType,
+
+		@JsonProperty("session_id") String sessionId,
+
+		@JsonProperty("uuid") String uuid,
+
+		@JsonProperty("parent_tool_use_id") String parentToolUseId,
+
+		@JsonProperty("ttft_ms") Long ttftMs,
+
+		@JsonProperty("event") Map<String, Object> event) implements Message {
+
+	@Override
+	public String getType() {
+		return "stream_event";
+	}
+
+	@Override
+	public String toString() {
+		return String.format("[StreamEvent: %s session=%s]",
+				eventType != null ? eventType : "unknown", sessionId);
+	}
+
+	public static StreamEventMessage of(String eventType, String sessionId, String uuid,
+			String parentToolUseId, Long ttftMs, Map<String, Object> event) {
+		return new StreamEventMessage(eventType, sessionId, uuid, parentToolUseId, ttftMs, event);
+	}
+
+}

--- a/claude-code-sdk/src/test/java/org/springaicommunity/claude/agent/sdk/parsing/MessageParserTest.java
+++ b/claude-code-sdk/src/test/java/org/springaicommunity/claude/agent/sdk/parsing/MessageParserTest.java
@@ -24,6 +24,7 @@ import org.springaicommunity.claude.agent.sdk.types.AssistantMessage;
 import org.springaicommunity.claude.agent.sdk.types.ContentBlock;
 import org.springaicommunity.claude.agent.sdk.types.Message;
 import org.springaicommunity.claude.agent.sdk.types.ResultMessage;
+import org.springaicommunity.claude.agent.sdk.types.StreamEventMessage;
 import org.springaicommunity.claude.agent.sdk.types.UserMessage;
 
 import java.util.List;
@@ -302,6 +303,112 @@ class MessageParserTest {
 			UserMessage user = (UserMessage) message;
 
 			assertThat(user.content()).isNotNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Stream Event Message Parsing")
+	class StreamEventMessageParsing {
+
+		/**
+		 * Regression test for GitHub issue #12.
+		 * Previously, stream_event messages caused a noisy ERROR log and were silently dropped.
+		 */
+		@Test
+		@DisplayName("should parse stream_event with message_start inner event without error")
+		void shouldParseStreamEventWithMessageStart() throws Exception {
+			String json = """
+					{
+						"type": "stream_event",
+						"event": {
+							"type": "message_start",
+							"message": {
+								"id": "0632da1ab4447f86b48dc29e67e33d79",
+								"type": "message",
+								"role": "assistant",
+								"content": [],
+								"model": "claude-opus-4-5",
+								"stop_reason": null,
+								"stop_sequence": null,
+								"usage": {
+									"input_tokens": 126,
+									"output_tokens": 0
+								}
+							}
+						},
+						"session_id": "407b9016-fdf4-4ac2-adb7-78710fe677da",
+						"parent_tool_use_id": null,
+						"uuid": "5bdb223c-f202-40df-b2d7-fd446ed693f7",
+						"ttft_ms": 1186
+					}
+					""";
+
+			Message message = parser.parseMessage(json);
+
+			assertThat(message).isInstanceOf(StreamEventMessage.class);
+			StreamEventMessage streamEvent = (StreamEventMessage) message;
+
+			assertThat(streamEvent.getType()).isEqualTo("stream_event");
+			assertThat(streamEvent.sessionId()).isEqualTo("407b9016-fdf4-4ac2-adb7-78710fe677da");
+			assertThat(streamEvent.uuid()).isEqualTo("5bdb223c-f202-40df-b2d7-fd446ed693f7");
+			assertThat(streamEvent.ttftMs()).isEqualTo(1186L);
+			assertThat(streamEvent.eventType()).isEqualTo("message_start");
+			assertThat(streamEvent.event()).isNotNull();
+			assertThat(streamEvent.event()).containsKey("type");
+			assertThat(streamEvent.event()).containsKey("message");
+		}
+
+		@Test
+		@DisplayName("should parse stream_event with content_block_delta inner event")
+		void shouldParseStreamEventWithContentBlockDelta() throws Exception {
+			String json = """
+					{
+						"type": "stream_event",
+						"event": {
+							"type": "content_block_delta",
+							"index": 0,
+							"delta": {
+								"type": "text_delta",
+								"text": "Hello, streaming world!"
+							}
+						},
+						"session_id": "407b9016-fdf4-4ac2-adb7-78710fe677da",
+						"uuid": "abc-123",
+						"ttft_ms": null
+					}
+					""";
+
+			Message message = parser.parseMessage(json);
+
+			assertThat(message).isInstanceOf(StreamEventMessage.class);
+			StreamEventMessage streamEvent = (StreamEventMessage) message;
+			assertThat(streamEvent.eventType()).isEqualTo("content_block_delta");
+			assertThat(streamEvent.ttftMs()).isNull();
+			assertThat(streamEvent.event()).containsKey("delta");
+			assertThat(streamEvent.event()).containsKey("index");
+		}
+
+		@Test
+		@DisplayName("should parse stream_event with message_stop inner event")
+		void shouldParseStreamEventWithMessageStop() throws Exception {
+			String json = """
+					{
+						"type": "stream_event",
+						"event": {
+							"type": "message_stop"
+						},
+						"session_id": "407b9016-fdf4-4ac2-adb7-78710fe677da",
+						"uuid": "xyz-789"
+					}
+					""";
+
+			Message message = parser.parseMessage(json);
+
+			assertThat(message).isInstanceOf(StreamEventMessage.class);
+			StreamEventMessage streamEvent = (StreamEventMessage) message;
+			assertThat(streamEvent.eventType()).isEqualTo("message_stop");
+			assertThat(streamEvent.ttftMs()).isNull();
 		}
 
 	}


### PR DESCRIPTION
## Problem

When `CLIOptions.includePartialMessages(true)` is set, the Claude CLI emits `stream_event` messages that wrap Anthropic API streaming events (e.g. `message_start`, `content_block_delta`, `message_stop`). The `MessageParser` had no case for this type, so every `stream_event` hit the `default` branch, printing a noisy `ERROR` log and silently dropping the message.

Fixes #12.

## Root Cause

`MessageParser.parseMessageFromNode()` used a switch on the `type` field with cases only for `user`, `assistant`, `system`, and `result`. A `stream_event` message like:

```json
{
  "type": "stream_event",
  "event": { "type": "message_start", "message": { ... } },
  "session_id": "407b9016-...",
  "uuid": "5bdb223c-...",
  "ttft_ms": 1186
}
```

fell through to:
```java
logger.error("Unrecognized message type 'stream_event' — skipping...");
yield null;
```

## Solution

### New type: `StreamEventMessage`
A Java record implementing `Message` that captures:
- `eventType` — the inner event's `type` field (e.g. `message_start`)
- `sessionId`, `uuid`, `parentToolUseId`, `ttftMs` — CLI envelope metadata
- `event` — the full inner event payload as `Map<String, Object>`

### Changes
| File | Change |
|------|--------|
| `types/StreamEventMessage.java` | New record implementing `Message` |
| `types/Message.java` | Registered `StreamEventMessage` in `@JsonSubTypes` |
| `parsing/MessageParser.java` | Added `case "stream_event"` and `parseStreamEventMessage()` method; logs at `DEBUG` not `ERROR` |
| `parsing/MessageParserTest.java` | Added `StreamEventMessageParsing` nested test class with 3 regression tests |

## Testing

Added regression tests covering:
- `message_start` event (the exact JSON from issue #12)
- `content_block_delta` event with delta payload
- `message_stop` event with minimal fields

All existing tests continue to pass.

## Before / After

**Before** — every partial message logged an error:
```
ERROR: Unrecognized message type 'stream_event' — skipping. Raw JSON: {...}
```

**After** — partial messages are parsed and available as `StreamEventMessage` instances with `DEBUG`-level logging.